### PR TITLE
SLING-13012 migrate to o.a.felix.webconsole 5.x and jakarta servlet

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     </parent>
 
     <artifactId>org.apache.sling.serviceuser.webconsole</artifactId>
-    <version>1.0.5-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
 
     <name>Apache Sling Service User Web Console</name>
     <description>Provides an OSGi Web Console for creating, updating and viewing Service Users.</description>
@@ -40,9 +40,15 @@
     </properties>
     <dependencies>
         <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.api</artifactId>
-            <version>2.25.4</version>
+            <version>3.0.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -109,8 +115,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <version>6.0.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -124,7 +131,7 @@
         <dependency>
             <groupId>org.apache.felix</groupId>
             <artifactId>org.apache.felix.webconsole</artifactId>
-            <version>4.2.0</version>
+            <version>5.0.10</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -164,7 +171,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.testing.sling-mock.junit5</artifactId>
-            <version>3.5.6</version>
+            <version>4.0.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/org/apache/sling/serviceuser/webconsole/impl/ServiceUserWebConsolePlugin.java
+++ b/src/main/java/org/apache/sling/serviceuser/webconsole/impl/ServiceUserWebConsolePlugin.java
@@ -27,10 +27,6 @@ import javax.jcr.security.AccessControlList;
 import javax.jcr.security.AccessControlManager;
 import javax.jcr.security.AccessControlPolicy;
 import javax.jcr.security.Privilege;
-import javax.servlet.Servlet;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -54,14 +50,17 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.StreamSupport;
 
+import jakarta.servlet.Servlet;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
-import org.apache.felix.webconsole.AbstractWebConsolePlugin;
-import org.apache.felix.webconsole.WebConsoleConstants;
-import org.apache.felix.webconsole.WebConsoleUtil;
+import org.apache.felix.webconsole.servlet.AbstractServlet;
+import org.apache.felix.webconsole.servlet.ServletConstants;
 import org.apache.jackrabbit.JcrConstants;
 import org.apache.jackrabbit.api.security.principal.PrincipalManager;
 import org.apache.jackrabbit.api.security.user.Authorizable;
@@ -102,12 +101,12 @@ import org.slf4j.LoggerFactory;
         service = Servlet.class,
         property = {
             Constants.SERVICE_DESCRIPTION + "=Apache Sling Service User Manager Web Console Plugin",
-            WebConsoleConstants.PLUGIN_LABEL + "=" + ServiceUserWebConsolePlugin.LABEL,
-            WebConsoleConstants.PLUGIN_TITLE + "=" + ServiceUserWebConsolePlugin.TITLE,
-            WebConsoleConstants.PLUGIN_CATEGORY + "=Sling"
+            ServletConstants.PLUGIN_LABEL + "=" + ServiceUserWebConsolePlugin.LABEL,
+            ServletConstants.PLUGIN_TITLE + "=" + ServiceUserWebConsolePlugin.TITLE,
+            ServletConstants.PLUGIN_CATEGORY + "=Sling"
         })
 @SuppressWarnings("serial")
-public class ServiceUserWebConsolePlugin extends AbstractWebConsolePlugin {
+public class ServiceUserWebConsolePlugin extends AbstractServlet {
 
     private static final String PROP_USER_MAPPING = "user.mapping";
     private static final String NT_SLING_OSGI_CONFIG = "sling:OsgiConfig";
@@ -362,8 +361,7 @@ public class ServiceUserWebConsolePlugin extends AbstractWebConsolePlugin {
                                     StandardCharsets.UTF_8.toString()));
                     params.add(PN_USER + "=" + URLEncoder.encode(name, StandardCharsets.UTF_8.toString()));
 
-                    WebConsoleUtil.sendRedirect(
-                            request, response, "/system/console/" + LABEL + "?" + StringUtils.join(params, "&"));
+                    response.sendRedirect("/system/console/" + LABEL + "?" + StringUtils.join(params, "&"));
                 } else {
                     sendErrorRedirect(request, response, "Unable to update service user permissions!");
                 }
@@ -509,11 +507,6 @@ public class ServiceUserWebConsolePlugin extends AbstractWebConsolePlugin {
         return bundles;
     }
 
-    @Override
-    public String getLabel() {
-        return LABEL;
-    }
-
     private Resource getOrCreateServiceUser(HttpServletRequest request, ResourceResolver resolver) {
 
         final String name = getParameter(request, PN_NAME, "");
@@ -642,11 +635,6 @@ public class ServiceUserWebConsolePlugin extends AbstractWebConsolePlugin {
             }
         }
         return names;
-    }
-
-    @Override
-    public String getTitle() {
-        return TITLE;
     }
 
     private boolean hasPrincipal(Mapping map, String name) {
@@ -803,7 +791,7 @@ public class ServiceUserWebConsolePlugin extends AbstractWebConsolePlugin {
                 pw.print("<a href='/system/console/configMgr/");
                 pw.print(xss.encodeForHTMLAttr(configPid));
                 pw.print("'>");
-                pw.print(xss.encodeForHTML(ObjectUtils.defaultIfNull(configPid, "")));
+                pw.print(xss.encodeForHTML(ObjectUtils.getIfNull(configPid, "")));
                 pw.print("</a>");
                 pw.println("<br>");
             }
@@ -955,7 +943,7 @@ public class ServiceUserWebConsolePlugin extends AbstractWebConsolePlugin {
     }
 
     @Override
-    protected void renderContent(HttpServletRequest request, HttpServletResponse response)
+    public void renderContent(HttpServletRequest request, HttpServletResponse response)
             throws ServletException, IOException {
 
         final PrintWriter pw = response.getWriter();
@@ -1046,8 +1034,7 @@ public class ServiceUserWebConsolePlugin extends AbstractWebConsolePlugin {
 
         params.add(PN_ALERT + "=" + URLEncoder.encode(alert, StandardCharsets.UTF_8.toString()));
 
-        WebConsoleUtil.sendRedirect(
-                request, response, "/system/console/" + LABEL + "?" + StringUtils.join(params, "&"));
+        response.sendRedirect("/system/console/" + LABEL + "?" + StringUtils.join(params, "&"));
     }
 
     private void tableEnd(PrintWriter pw) {
@@ -1090,7 +1077,7 @@ public class ServiceUserWebConsolePlugin extends AbstractWebConsolePlugin {
                 for (int i = 0; i < Array.getLength(value); i++) {
                     Object itemValue = Array.get(value, i);
                     pw.print(xss.encodeForHTML(
-                            ObjectUtils.defaultIfNull(itemValue, "").toString()));
+                            ObjectUtils.getIfNull(itemValue, "").toString()));
                     pw.println("<br>");
                 }
             } else {

--- a/src/main/java/org/apache/sling/serviceuser/webconsole/impl/ServiceUserWebConsolePlugin.java
+++ b/src/main/java/org/apache/sling/serviceuser/webconsole/impl/ServiceUserWebConsolePlugin.java
@@ -132,15 +132,15 @@ public class ServiceUserWebConsolePlugin extends AbstractServlet {
 
     private static final Logger log = LoggerFactory.getLogger(ServiceUserWebConsolePlugin.class);
 
-    private final BundleContext bundleContext;
+    private final transient BundleContext bundleContext;
 
-    private final XSSAPI xss;
+    private final transient XSSAPI xss;
 
-    private final ResourceResolverFactory resolverFactory;
+    private final transient ResourceResolverFactory resolverFactory;
 
-    private final ServiceUserMapper mapper;
+    private final transient ServiceUserMapper mapper;
 
-    private final ConfigurationAdmin configAdmin;
+    private final transient ConfigurationAdmin configAdmin;
 
     @Activate
     public ServiceUserWebConsolePlugin(
@@ -595,7 +595,7 @@ public class ServiceUserWebConsolePlugin extends AbstractServlet {
     }
 
     /**
-     * Called internally by {@link AbstractWebConsolePlugin} to load resources.
+     * Called internally by {@link AbstractServlet} to load resources.
      *
      * This particular implementation depends on the label. As example, if the
      * plugin is accessed as <code>/system/console/abc</code>, and the plugin
@@ -607,6 +607,7 @@ public class ServiceUserWebConsolePlugin extends AbstractServlet {
      * @param path the path to read.
      * @return the URL of the resource or <code>null</code> if not found.
      */
+    @Override
     protected URL getResource(String path) {
         String base = "/" + LABEL + "/";
         return (path != null && path.startsWith(base))

--- a/src/main/resources/res/ui/serviceusermanager.js
+++ b/src/main/resources/res/ui/serviceusermanager.js
@@ -14,14 +14,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-var repeatingRemove = function(){
+const repeatingRemove = function(){
 	$(this).parents('.repeating-item').remove();
 	return false;
 }
 $('.repeating-remove').click(repeatingRemove);
 $('.repeating-add').click(function(){
-	var idx = $('.repeating-container').data('length');
-	var div = $('.repeating-container').append('<tr class="repeating-item"><td>'+'<input type="text"  name="acl-path-'
+	const idx = $('.repeating-container').data('length');
+	const div = $('.repeating-container').append('<tr class="repeating-item"><td>'+'<input type="text"  name="acl-path-'
 			+ idx + '"  style="width:100%" /></td><td>'+
 			'<input type="text" list="data-privileges" name="acl-privilege-' + idx + '" style="width:100%" />'+
 			'</td><td><input type="button" value="-" class="repeating-remove" /></td></tr>');

--- a/src/test/java/org/apache/sling/serviceuser/webconsole/impl/ServiceUserWebConsolePluginTest.java
+++ b/src/test/java/org/apache/sling/serviceuser/webconsole/impl/ServiceUserWebConsolePluginTest.java
@@ -28,8 +28,6 @@ import javax.jcr.security.AccessControlList;
 import javax.jcr.security.AccessControlManager;
 import javax.jcr.security.AccessControlPolicy;
 import javax.jcr.security.Privilege;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
 import java.net.URLEncoder;
@@ -46,6 +44,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
 
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletResponse;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jackrabbit.JcrConstants;
 import org.apache.jackrabbit.api.JackrabbitSession;
@@ -67,8 +67,8 @@ import org.apache.sling.testing.mock.osgi.MockBundle;
 import org.apache.sling.testing.mock.sling.ResourceResolverType;
 import org.apache.sling.testing.mock.sling.junit5.SlingContext;
 import org.apache.sling.testing.mock.sling.junit5.SlingContextExtension;
-import org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletRequest;
-import org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletResponse;
+import org.apache.sling.testing.mock.sling.servlet.MockSlingJakartaHttpServletRequest;
+import org.apache.sling.testing.mock.sling.servlet.MockSlingJakartaHttpServletResponse;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
@@ -176,7 +176,7 @@ class ServiceUserWebConsolePluginTest {
     @MethodSource("testDoPostArgs")
     void testDoPost(Map<String, Object> requestParams, Set<TestConfigOptions> options)
             throws ServletException, IOException, RepositoryException, LoginException {
-        final @NotNull MockSlingHttpServletRequest request = context.request();
+        final @NotNull MockSlingJakartaHttpServletRequest request = context.jakartaRequest();
         request.setParameterMap(requestParams);
 
         final ResourceResolver rr = request.getResourceResolver();
@@ -245,7 +245,7 @@ class ServiceUserWebConsolePluginTest {
                     .getPolicies(anyString());
         }
 
-        final @NotNull MockSlingHttpServletResponse response = context.response();
+        final @NotNull MockSlingJakartaHttpServletResponse response = context.jakartaResponse();
 
         // NOTE: replace the replaceAccessControlEntry method with one that does nothing since we are not
         //  testing that functionality here and it doesn't work with the partially mocked acm.
@@ -276,7 +276,7 @@ class ServiceUserWebConsolePluginTest {
 
     @Test
     void testDoPostWithFailureInCreateOrUpdateMapping() throws ServletException, IOException {
-        final @NotNull MockSlingHttpServletRequest request = context.request();
+        final @NotNull MockSlingJakartaHttpServletRequest request = context.jakartaRequest();
 
         // simulate the resolver request attribute existing
         final ResourceResolver rr = Mockito.spy(request.getResourceResolver());
@@ -290,7 +290,7 @@ class ServiceUserWebConsolePluginTest {
         params.put(ServiceUserWebConsolePlugin.PN_APP_PATH, "/apps/myapp1");
         request.setParameterMap(params);
 
-        final @NotNull MockSlingHttpServletResponse response = context.response();
+        final @NotNull MockSlingJakartaHttpServletResponse response = context.jakartaResponse();
 
         // provide a mocked AccessControlManager object
         JackrabbitAccessControlManager acm = Mockito.mock(JackrabbitAccessControlManager.class);
@@ -306,7 +306,7 @@ class ServiceUserWebConsolePluginTest {
 
     @Test
     void testDoPostWithFailureInUpdatePrivileges() throws ServletException, IOException, RepositoryException {
-        final @NotNull MockSlingHttpServletRequest request = context.request();
+        final @NotNull MockSlingJakartaHttpServletRequest request = context.jakartaRequest();
 
         // simulate the resolver request attribute existing
         final ResourceResolver rr = Mockito.spy(request.getResourceResolver());
@@ -318,7 +318,7 @@ class ServiceUserWebConsolePluginTest {
         params.put(ServiceUserWebConsolePlugin.PN_APP_PATH, "/apps/myapp1");
         request.setParameterMap(params);
 
-        final @NotNull MockSlingHttpServletResponse response = context.response();
+        final @NotNull MockSlingJakartaHttpServletResponse response = context.jakartaResponse();
 
         // simulate an exception thrown during the updatePrivileges logic
         Session jcrSession = Mockito.spy(rr.adaptTo(Session.class));
@@ -337,7 +337,7 @@ class ServiceUserWebConsolePluginTest {
     @ValueSource(booleans = {true, false})
     void testDoPostWithFailureToCreateServiceUser(boolean throwExceptionDuringRefresh)
             throws ServletException, IOException, RepositoryException {
-        final @NotNull MockSlingHttpServletRequest request = context.request();
+        final @NotNull MockSlingJakartaHttpServletRequest request = context.jakartaRequest();
 
         // simulate a RepositoryException thrown while creating the system user
         final ResourceResolver rr = Mockito.spy(request.getResourceResolver());
@@ -364,7 +364,7 @@ class ServiceUserWebConsolePluginTest {
         params.put(ServiceUserWebConsolePlugin.PN_APP_PATH, "/apps/myapp1");
         request.setParameterMap(params);
 
-        final @NotNull MockSlingHttpServletResponse response = context.response();
+        final @NotNull MockSlingJakartaHttpServletResponse response = context.jakartaResponse();
 
         plugin.doPost(request, response);
 
@@ -376,7 +376,7 @@ class ServiceUserWebConsolePluginTest {
 
     @Test
     void testDoPostWithCaughtLoginException() throws LoginException, ServletException, IOException {
-        final @NotNull MockSlingHttpServletRequest request = context.request();
+        final @NotNull MockSlingJakartaHttpServletRequest request = context.jakartaRequest();
 
         mockResolverFactoryThrowsLoginException();
 
@@ -386,7 +386,7 @@ class ServiceUserWebConsolePluginTest {
         params.put(ServiceUserWebConsolePlugin.PN_APP_PATH, "/apps/myapp1");
         request.setParameterMap(params);
 
-        final @NotNull MockSlingHttpServletResponse response = context.response();
+        final @NotNull MockSlingJakartaHttpServletResponse response = context.jakartaResponse();
 
         plugin.doPost(request, response);
 
@@ -399,7 +399,7 @@ class ServiceUserWebConsolePluginTest {
     @SuppressWarnings("deprecation")
     @Test
     void testDoPostWithNullResourceResolver() throws LoginException, ServletException, IOException {
-        final @NotNull MockSlingHttpServletRequest request = context.request();
+        final @NotNull MockSlingJakartaHttpServletRequest request = context.jakartaRequest();
 
         // simulate the resolverFactory returning a null administrative resource resolver
         ResourceResolverFactory rrf =
@@ -414,7 +414,7 @@ class ServiceUserWebConsolePluginTest {
         params.put(ServiceUserWebConsolePlugin.PN_APP_PATH, "/apps/myapp1");
         request.setParameterMap(params);
 
-        final @NotNull MockSlingHttpServletResponse response = context.response();
+        final @NotNull MockSlingJakartaHttpServletResponse response = context.jakartaResponse();
 
         plugin.doPost(request, response);
 
@@ -426,7 +426,7 @@ class ServiceUserWebConsolePluginTest {
 
     @Test
     void testDoPostWithIOExceptionDuringErrorRedirect() throws LoginException {
-        final @NotNull MockSlingHttpServletRequest request = context.request();
+        final @NotNull MockSlingJakartaHttpServletRequest request = context.jakartaRequest();
 
         mockResolverFactoryThrowsLoginException();
 
@@ -436,7 +436,7 @@ class ServiceUserWebConsolePluginTest {
         params.put(ServiceUserWebConsolePlugin.PN_APP_PATH, "/apps/myapp1");
         request.setParameterMap(params);
 
-        final @NotNull MockSlingHttpServletResponse response = Mockito.spy(context.response());
+        final @NotNull MockSlingJakartaHttpServletResponse response = Mockito.spy(context.jakartaResponse());
         Mockito.doThrow(IOException.class).when(response).sendRedirect(anyString());
 
         assertDoesNotThrow(() -> plugin.doPost(request, response));
@@ -467,9 +467,9 @@ class ServiceUserWebConsolePluginTest {
     @MethodSource("testDoPostWithMissingParametersArgs")
     void testDoPostWithMissingParameters(Map<String, Object> params, Map<String, Object> expectedRedirectParams)
             throws ServletException, IOException {
-        final @NotNull MockSlingHttpServletRequest request = context.request();
+        final @NotNull MockSlingJakartaHttpServletRequest request = context.jakartaRequest();
         request.setParameterMap(params);
-        final @NotNull MockSlingHttpServletResponse response = context.response();
+        final @NotNull MockSlingJakartaHttpServletResponse response = context.jakartaResponse();
 
         plugin.doPost(request, response);
 
@@ -489,14 +489,6 @@ class ServiceUserWebConsolePluginTest {
     }
 
     /**
-     * Test method for {@link org.apache.sling.serviceuser.webconsole.impl.ServiceUserWebConsolePlugin#getLabel()}.
-     */
-    @Test
-    void testGetLabel() {
-        assertEquals("serviceusers", plugin.getLabel());
-    }
-
-    /**
      * Test method for {@link org.apache.sling.serviceuser.webconsole.impl.ServiceUserWebConsolePlugin#getResource(java.lang.String)}.
      */
     @Test
@@ -509,14 +501,6 @@ class ServiceUserWebConsolePluginTest {
     @ValueSource(strings = {"/serviceusers/invalid.js"})
     void testGetResourceForInvalidPath(String path) {
         assertNull(plugin.getResource(path));
-    }
-
-    /**
-     * Test method for {@link org.apache.sling.serviceuser.webconsole.impl.ServiceUserWebConsolePlugin#getTitle()}.
-     */
-    @Test
-    void testGetTitle() {
-        assertEquals("Service Users", plugin.getTitle());
     }
 
     /**
@@ -544,7 +528,7 @@ class ServiceUserWebConsolePluginTest {
         Mockito.doReturn(new Bundle[] {bc.getBundle()}).when(bc).getBundles();
         ReflectionTools.setFieldWithReflection(plugin, "bundleContext", bc);
 
-        final @NotNull MockSlingHttpServletRequest request = context.request();
+        final @NotNull MockSlingJakartaHttpServletRequest request = context.jakartaRequest();
         Map<String, Object> params = new HashMap<>();
         params.put(ServiceUserWebConsolePlugin.PN_ACTION, action);
         params.put(ServiceUserWebConsolePlugin.PN_ALERT, "some alert here");
@@ -565,7 +549,7 @@ class ServiceUserWebConsolePluginTest {
         Mockito.doReturn(supportedPrivileges).when(acm).getSupportedPrivileges("/");
         MockJcr.setAccessControlManager(rr.adaptTo(Session.class), acm);
 
-        final @NotNull MockSlingHttpServletResponse response = context.response();
+        final @NotNull MockSlingJakartaHttpServletResponse response = context.jakartaResponse();
         plugin.renderContent(request, response);
         final String outputAsString = response.getOutputAsString();
         assertNotNull(outputAsString);
@@ -574,13 +558,13 @@ class ServiceUserWebConsolePluginTest {
     @Test
     void testRenderContentForServiceUsersWithCaughtLoginException()
             throws ServletException, IOException, LoginException {
-        final @NotNull MockSlingHttpServletRequest request = context.request();
+        final @NotNull MockSlingJakartaHttpServletRequest request = context.jakartaRequest();
         Map<String, Object> params = new HashMap<>();
         request.setParameterMap(params);
 
         mockResolverFactoryThrowsLoginException();
 
-        final @NotNull MockSlingHttpServletResponse response = context.response();
+        final @NotNull MockSlingJakartaHttpServletResponse response = context.jakartaResponse();
         plugin.renderContent(request, response);
         final String outputAsString = response.getOutputAsString();
         assertNotNull(outputAsString);
@@ -611,7 +595,7 @@ class ServiceUserWebConsolePluginTest {
                 "another.bundle1", "subservice2", null, Arrays.asList("otheruser1", "otheruser2"), 2);
         mockMappingConfigAmendment("another.bundle2", "subservice3", "otheruser3", 5);
 
-        final @NotNull MockSlingHttpServletRequest request = context.request();
+        final @NotNull MockSlingJakartaHttpServletRequest request = context.jakartaRequest();
 
         final ResourceResolver rr = request.getResourceResolver();
         final @Nullable Session jcrSession = rr.adaptTo(Session.class);
@@ -682,7 +666,7 @@ class ServiceUserWebConsolePluginTest {
             request.setAttribute("org.apache.sling.auth.core.ResourceResolver", rr);
         }
 
-        final @NotNull MockSlingHttpServletResponse response = context.response();
+        final @NotNull MockSlingJakartaHttpServletResponse response = context.jakartaResponse();
         plugin.renderContent(request, response);
         final String outputAsString = response.getOutputAsString();
         assertNotNull(outputAsString);
@@ -691,7 +675,7 @@ class ServiceUserWebConsolePluginTest {
     @Test
     void testRenderContentForServiceUserDetailsWithCaughtLoginException()
             throws ServletException, IOException, LoginException {
-        final @NotNull MockSlingHttpServletRequest request = context.request();
+        final @NotNull MockSlingJakartaHttpServletRequest request = context.jakartaRequest();
         Map<String, Object> params = new HashMap<>();
         params.put(ServiceUserWebConsolePlugin.PN_ACTION, "details");
         params.put(ServiceUserWebConsolePlugin.PN_USER, "myserviceuser1");
@@ -700,7 +684,7 @@ class ServiceUserWebConsolePluginTest {
         // simulate the resolverFactory throwing a LoginException
         mockResolverFactoryThrowsLoginException();
 
-        final @NotNull MockSlingHttpServletResponse response = context.response();
+        final @NotNull MockSlingJakartaHttpServletResponse response = context.jakartaResponse();
         plugin.renderContent(request, response);
         final String outputAsString = response.getOutputAsString();
         assertNotNull(outputAsString);
@@ -709,13 +693,13 @@ class ServiceUserWebConsolePluginTest {
 
     @Test
     void testRenderContentForUnknownAction() throws ServletException, IOException {
-        final @NotNull MockSlingHttpServletRequest request = context.request();
+        final @NotNull MockSlingJakartaHttpServletRequest request = context.jakartaRequest();
 
         Map<String, Object> params = new HashMap<>();
         params.put(ServiceUserWebConsolePlugin.PN_ACTION, "invalid");
         request.setParameterMap(params);
 
-        final @NotNull MockSlingHttpServletResponse response = context.response();
+        final @NotNull MockSlingJakartaHttpServletResponse response = context.jakartaResponse();
         plugin.renderContent(request, response);
         final String outputAsString = response.getOutputAsString();
         assertNotNull(outputAsString);


### PR DESCRIPTION
bump bundle major version to 2.0.0

bump org.apache.sling.api to 3.0.0
bump org.apache.felix.webconsole to 5.0.10
bump org.apache.sling.testing.sling-mock.junit5 to 4.0.2

migrate the javax.servlet references to jakarta.servlet

refactor the tests to use the jakarta servlet based apis